### PR TITLE
Add `-o` to scrot options in lock script.

### DIFF
--- a/scripts/lock.sh
+++ b/scripts/lock.sh
@@ -9,7 +9,7 @@ tmpbg='/tmp/lockscreen.png'
 
 (( $# )) && { icon=$1; }
 
-scrot "$tmpbg"
+scrot -o "$tmpbg"
 convert "$tmpbg" -scale 10% -scale 1000% "$tmpbg"
 convert "$tmpbg" "$icon" -gravity center -composite -matte "$tmpbg"
 i3lock -i "$tmpbg"


### PR DESCRIPTION
Otherwise, scrot would just create `lockscreen_00x.png` files in `/tmp`.